### PR TITLE
Non-automatic weapon fire fix

### DIFF
--- a/components/game_mod/bg_weapons.cpp
+++ b/components/game_mod/bg_weapons.cpp
@@ -228,7 +228,9 @@ int PM_Weapon_WeaponTimeAdjust(pmove_t *pm, pml_t *pml)
 			else
 				holdingFireBtn = pm->cmd.button_bits.testBit(0) != 0;
 
-			if ((*weaponState < WEAPON_OFFHAND_INIT || *weaponState > WEAPON_OFFHAND_END)
+			if (!IS_WEAPONSTATE_OFFHAND(*weaponState)
+				&& *weaponState != WEAPON_DROPPING_QUICK
+				&& *weaponState != WEAPON_RAISING
 				&& (pausedAfterFiring || holdingGrenadeBtn)
 				&& holdingFireBtn
 				&& ps->weapon == pm->cmd.weapon
@@ -254,7 +256,7 @@ int PM_Weapon_WeaponTimeAdjust(pmove_t *pm, pml_t *pml)
 			}
 			else
 			{
-				if ((!holdingFireBtn || ps->weapFlags & 0x400) && !BurstFirePending(ps))
+				if ((!holdingFireBtn || ps->weapFlags & 0x400 || *weaponState == WEAPON_DROPPING_QUICK || *weaponState == WEAPON_RAISING) && !BurstFirePending(ps))
 					*weaponShotCount = 0;
 
 				*weaponTime = 0;

--- a/components/game_mod/bg_weapons.h
+++ b/components/game_mod/bg_weapons.h
@@ -77,6 +77,14 @@ enum weaponstate_t
 								(x) == WEAPON_CONT_FIRE_LOOP || \
 								IS_WEAPONSTATE_MELEE(x))
 
+#define IS_WEAPONSTATE_OFFHAND(x) (\
+								(x) == WEAPON_OFFHAND_INIT || \
+								(x) == WEAPON_OFFHAND_PREPARE || \
+								(x) == WEAPON_OFFHAND_HOLD || \
+								(x) == WEAPON_OFFHAND_START || \
+								(x) == WEAPON_OFFHAND || \
+								(x) == WEAPON_OFFHAND_END)
+
 struct usercmd_s
 {
 	int serverTime;


### PR DESCRIPTION
Fixed a bug that caused players to have no weapon in their hand if they
held the fire button and threw a grenade while holding a non-automatic
weapon

Fixed a bug that caused players to not be able to fire a non-automatic
weapon if they held the fire button and switched weapons